### PR TITLE
feat: Add `line!` attribute macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ let styled_greeting = styled!(Color::Green, "hello {name}");
 let styled_greeting = styled!(Modifier::BOLD, "hello {name}");
 ```
 
+## Line
+
+The `line!` macro creates a `Line` that contains a sequence of spans. It is similar to the `vec!` macro.
+
+```rust
+use ratatui::prelude::*;
+use ratatui_macros::line;
+
+let name = "world!";
+let line = line!["hello", format!("{name}")];
+let line = line!["bye"; 2];
+```
+
 ## Contributing
 
 Contributions to `ratatui-macros` are welcome! Whether it's submitting a bug report, a feature
@@ -143,10 +156,8 @@ request, or a pull request, all forms of contributions are valued and appreciate
 [CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui-macros/ci.yml?logo=github&style=flat-square
 [Docs.rs badge]: https://img.shields.io/docsrs/ratatui-macros?logo=rust&style=flat-square
 [Crate Downloads badge]: https://img.shields.io/crates/d/ratatui-macros?logo=rust&style=flat-square
-
 [ratatui_macros crate]: https://crates.io/crates/ratatui-macros
 [API Docs]: https://docs.rs/ratatui-macros
 [CI Status]: https://github.com/kdheepak/ratatui-macros/actions
-
 [Ratatui]: https://github.com/ratatui-org/ratatui
 [Layout concepts]: https://ratatui.rs/concepts/layout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@
 
 mod color;
 mod layout;
+mod line;
 mod span;

--- a/src/line.rs
+++ b/src/line.rs
@@ -4,17 +4,38 @@
 ///
 /// # Examples
 ///
+/// * Create a [`Line`] containing a vector of [`Span`]s:
+///
 /// ```rust
 /// # use ratatui::prelude::*;
 /// use ratatui_macros::{line, raw};
 ///
 /// let line = line!["hello", "world"];
-/// let line = line![raw!("hello {}", "world"), raw!("goodbye {}", "world")];
 /// let line = line!["hello".red(), "world".red().bold()];
+/// ```
+///
+/// * Create a [`Line`] from a given [`Span`] and size:
+///
+/// ```rust
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::line;
+///
 /// let line = line!["hello"; 2];
 /// ```
 ///
+/// * Use [`raw!`] or [`styled!`] macros inside [`line!`] macro for formatting.
+///
+/// ```rust
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::{line, raw, styled};
+///
+/// let line = line![raw!("hello {}", "world"), styled!(Modifier::BOLD, "goodbye {}", "world")];
+/// ```
+///
 /// [`Line`]: crate::text::Line
+/// [`Span`]: crate::text::Span
+/// [`raw!`]: crate::raw
+/// [`styled!`]: crate::raw
 #[macro_export]
 macro_rules! line {
     () => {

--- a/src/line.rs
+++ b/src/line.rs
@@ -51,7 +51,7 @@ mod tests {
         assert_eq!(line, Line::from(vec!["hello".into(), "hello".into()]));
 
         // vec count syntax with span
-        let line = line!["hello"; 2];
-        assert_eq!(line, Line::from(vec![crate::raw!("hello"), "hello".into()]));
+        let line = line![Span::raw("hello"); 2];
+        assert_eq!(line, Line::from(vec!["hello".into(), "hello".into()]));
     }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -35,7 +35,7 @@
 /// [`Line`]: crate::text::Line
 /// [`Span`]: crate::text::Span
 /// [`raw!`]: crate::raw
-/// [`styled!`]: crate::raw
+/// [`styled!`]: crate::styled
 #[macro_export]
 macro_rules! line {
     () => {

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,0 +1,57 @@
+/// A macro for creating a [`Line`] using vec! syntax.
+///
+/// `line!` is similar to the [`vec!`] macro, but it returns a [`Line`] instead of a `Vec`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::{line, raw};
+///
+/// let line = line!["hello", "world"];
+/// let line = line![raw!("hello {}", "world"), raw!("goodbye {}", "world")];
+/// let line = line!["hello".red(), "world".red().bold()];
+/// let line = line!["hello"; 2];
+/// ```
+///
+/// [`Line`]: crate::text::Line
+#[macro_export]
+macro_rules! line {
+    () => {
+        ratatui::text::Line::default()
+    };
+    ($span:expr; $n:expr) => {
+      ratatui::text::Line::from(vec![$span.into(); $n])
+    };
+    ($($span:expr),+ $(,)?) => {{
+        let mut line = ratatui::text::Line::default();
+        $(
+            line.push_span($span);
+         )+
+         line
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::prelude::*;
+
+    #[test]
+    fn line() {
+        // literal
+        let line = line!["hello", "world"];
+        assert_eq!(line, Line::from(vec!["hello".into(), "world".into()]));
+
+        // raw instead line
+        let line = line![crate::raw!("hello"), "world"];
+        assert_eq!(line, Line::from(vec!["hello".into(), "world".into()]));
+
+        // vec count syntax
+        let line = line!["hello"; 2];
+        assert_eq!(line, Line::from(vec!["hello".into(), "hello".into()]));
+
+        // vec count syntax with span
+        let line = line!["hello"; 2];
+        assert_eq!(line, Line::from(vec![crate::raw!("hello"), "hello".into()]));
+    }
+}

--- a/src/line.rs
+++ b/src/line.rs
@@ -14,7 +14,7 @@
 /// let line = line!["hello".red(), "world".red().bold()];
 /// ```
 ///
-/// * Create a [`Line`] from a given [`Span`] and size:
+/// * Create a [`Line`] from a given [`Span`] repeated some amount of times:
 ///
 /// ```rust
 /// # use ratatui::prelude::*;

--- a/src/line.rs
+++ b/src/line.rs
@@ -34,6 +34,7 @@ macro_rules! line {
 
 #[cfg(test)]
 mod tests {
+    use crate::raw;
     use ratatui::prelude::*;
 
     #[test]
@@ -43,7 +44,7 @@ mod tests {
         assert_eq!(line, Line::from(vec!["hello".into(), "world".into()]));
 
         // raw instead line
-        let line = line![crate::raw!("hello"), "world"];
+        let line = line![raw!("hello"), "world"];
         assert_eq!(line, Line::from(vec!["hello".into(), "world".into()]));
 
         // vec count syntax

--- a/src/line.rs
+++ b/src/line.rs
@@ -24,11 +24,11 @@ macro_rules! line {
       ratatui::text::Line::from(vec![$span.into(); $n])
     };
     ($($span:expr),+ $(,)?) => {{
-        let mut line = ratatui::text::Line::default();
+        ratatui::text::Line::from(vec![
         $(
-            line.push_span($span);
-         )+
-         line
+            $span.into(),
+        )+
+        ])
     }};
 }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -34,7 +34,6 @@ macro_rules! line {
 
 #[cfg(test)]
 mod tests {
-    use crate::raw;
     use ratatui::prelude::*;
 
     #[test]
@@ -44,7 +43,7 @@ mod tests {
         assert_eq!(line, Line::from(vec!["hello".into(), "world".into()]));
 
         // raw instead line
-        let line = line![raw!("hello"), "world"];
+        let line = line![Span::raw("hello"), "world"];
         assert_eq!(line, Line::from(vec!["hello".into(), "world".into()]));
 
         // vec count syntax
@@ -52,7 +51,7 @@ mod tests {
         assert_eq!(line, Line::from(vec!["hello".into(), "hello".into()]));
 
         // vec count syntax with span
-        let line = line![Span::raw("hello"); 2];
+        let line = line![crate::raw!("hello"); 2];
         assert_eq!(line, Line::from(vec!["hello".into(), "hello".into()]));
     }
 }


### PR DESCRIPTION
This PR adds a `line!` attribute macro.

This makes it easier to construct a `Line` type from anything that can be converted into a `Span`.