### PR TITLE
feat: Better error messages for `span!` macro

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -53,7 +53,7 @@ macro_rules! span {
         ratatui::text::Span::raw(format!($string, $($arg)*))
     };
     ($style:expr, $($arg:tt)*) => {
-        compile_error!("first parameter must be a `ratatui::style::Style` followed by a semi-colon")
+        compile_error!("first parameter must be a formatting specifier followed by a comma OR a `ratatui::style::Style` followed by a semi-colon")
     };
     ($style:expr; $($arg:tt)*) => {
         ratatui::text::Span::styled(format!($($arg)*), $style)

--- a/src/span.rs
+++ b/src/span.rs
@@ -48,7 +48,7 @@
 ///
 /// ```compile_fail
 /// # use ratatui::prelude::*;
-/// use ratatui_macros::span;
+/// # use ratatui_macros::span;
 /// let span = span!(Modifier::BOLD, "hello world");
 /// ```
 ///
@@ -56,7 +56,7 @@
 ///
 /// ```rust
 /// # use ratatui::prelude::*;
-/// use ratatui_macros::span;
+/// # use ratatui_macros::span;
 /// let span = span!(Modifier::BOLD; "hello world");
 /// ```
 ///
@@ -64,7 +64,7 @@
 ///
 /// ```compile_fail
 /// # use ratatui::prelude::*;
-/// use ratatui_macros::span;
+/// # use ratatui_macros::span;
 /// let span = span!("hello", "world");
 /// ```
 ///
@@ -72,7 +72,7 @@
 ///
 /// ```rust
 /// # use ratatui::prelude::*;
-/// use ratatui_macros::span;
+/// # use ratatui_macros::span;
 /// let span = span!("hello {}", "world");
 /// ```
 ///

--- a/src/span.rs
+++ b/src/span.rs
@@ -42,7 +42,8 @@
 ///
 /// # Note
 ///
-/// The first parameter must be a formatting specifier followed by a comma OR a [`Style`] followed by a semicolon.
+/// The first parameter must be a formatting specifier followed by a comma OR
+/// anything that can be converted into a [`Style`] followed by a semicolon.
 ///
 /// For example, the following will fail to compile:
 ///

--- a/src/span.rs
+++ b/src/span.rs
@@ -53,7 +53,7 @@ macro_rules! span {
         ratatui::text::Span::raw(format!($string, $($arg)*))
     };
     ($style:expr, $($arg:tt)*) => {
-        compile_error!("first parameter must be a formatting specifier followed by a comma OR a `ratatui::style::Style` followed by a semi-colon")
+        compile_error!("first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semi-colon")
     };
     ($style:expr; $($arg:tt)*) => {
         ratatui::text::Span::styled(format!($($arg)*), $style)

--- a/src/span.rs
+++ b/src/span.rs
@@ -46,11 +46,17 @@
 /// [`Style`]: crate::style::Style
 #[macro_export]
 macro_rules! span {
+    ($string:literal) => {
+        ratatui::text::Span::raw(format!($string))
+    };
+    ($string:literal, $($arg:tt)*) => {
+        ratatui::text::Span::raw(format!($string, $($arg)*))
+    };
+    ($style:expr, $($arg:tt)*) => {
+        compile_error!("first parameter must be a style followed by a semi-colon")
+    };
     ($style:expr; $($arg:tt)*) => {
         ratatui::text::Span::styled(format!($($arg)*), $style)
-    };
-    ($($arg:tt)*) => {
-        ratatui::text::Span::raw(format!($($arg)*))
     };
 }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -53,7 +53,7 @@ macro_rules! span {
         ratatui::text::Span::raw(format!($string, $($arg)*))
     };
     ($style:expr, $($arg:tt)*) => {
-        compile_error!("first parameter must be a style followed by a semi-colon")
+        compile_error!("first parameter must be a `ratatui::style::Style` followed by a semi-colon")
     };
     ($style:expr; $($arg:tt)*) => {
         ratatui::text::Span::styled(format!($($arg)*), $style)

--- a/src/span.rs
+++ b/src/span.rs
@@ -40,6 +40,42 @@
 /// let span = span!(style; "test {:04}", 123);
 /// ```
 ///
+/// # Note
+///
+/// The first parameter must be a formatting specifier followed by a comma OR a [`Style`] followed by a semicolon.
+///
+/// For example, the following will fail to compile:
+///
+/// ```compile_fail
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::span;
+/// let span = span!(Modifier::BOLD, "hello world");
+/// ```
+///
+/// But this will work:
+///
+/// ```rust
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::span;
+/// let span = span!(Modifier::BOLD; "hello world");
+/// ```
+///
+/// The following will fail to compile:
+///
+/// ```compile_fail
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::span;
+/// let span = span!("hello", "world");
+/// ```
+///
+/// But this will work:
+///
+/// ```rust
+/// # use ratatui::prelude::*;
+/// use ratatui_macros::span;
+/// let span = span!("hello {}", "world");
+/// ```
+///
 /// [`Color`]: crate::style::Color
 /// [`Style`]: crate::style::Style
 /// [`Span`]: crate::text::Span
@@ -53,7 +89,7 @@ macro_rules! span {
         ratatui::text::Span::raw(format!($string, $($arg)*))
     };
     ($style:expr, $($arg:tt)*) => {
-        compile_error!("first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semi-colon")
+        compile_error!("first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semicolon")
     };
     ($style:expr; $($arg:tt)*) => {
         ratatui::text::Span::styled(format!($($arg)*), $style)

--- a/tests/ui/fails.rs
+++ b/tests/ui/fails.rs
@@ -1,5 +1,5 @@
 use ratatui::prelude::*;
-use ratatui_macros::constraints;
+use ratatui_macros::{constraints, span};
 
 fn main() {
     constraints![,];
@@ -13,4 +13,10 @@ fn main() {
     assert_eq!(b, Constraint::Length(2));
 
     let [a, b, c] = constraints![ == 1, == 10%, == 2; 4];
+
+    let _ = span!(Modifier::BOLD, "hello world");
+
+    let _ = span!("hello", "hello world");
+
+    let _ = span!("hello"; "hello world");
 }

--- a/tests/ui/fails.rs
+++ b/tests/ui/fails.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let _ = span!(Modifier::BOLD, "hello world");
 
-    // let _ = span!("hello", "hello world");
+    let _ = span!("hello", "hello world");
 
     // let _ = span!("hello"; "hello world");
 }

--- a/tests/ui/fails.rs
+++ b/tests/ui/fails.rs
@@ -17,6 +17,4 @@ fn main() {
     let _ = span!(Modifier::BOLD, "hello world");
 
     let _ = span!("hello", "hello world");
-
-    // let _ = span!("hello"; "hello world");
 }

--- a/tests/ui/fails.rs
+++ b/tests/ui/fails.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let _ = span!(Modifier::BOLD, "hello world");
 
-    let _ = span!("hello", "hello world");
+    // let _ = span!("hello", "hello world");
 
-    let _ = span!("hello"; "hello world");
+    // let _ = span!("hello"; "hello world");
 }

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -1,5 +1,5 @@
 error: No rules expected the token `,` while trying to match the end of the macro
- --> tests/ui/fails.rs:5:5
+Error:  --> tests/ui/fails.rs:5:5
   |
 5 |     constraints![,];
   |     ^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ error: No rules expected the token `,` while trying to match the end of the macr
   = note: this error originates in the macro `$crate::constraints` which comes from the expansion of the macro `constraints` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-  --> tests/ui/fails.rs:8:18
+Error:   --> tests/ui/fails.rs:8:18
    |
 8  |       let [a, b] = constraints![
    |  __________________^
@@ -24,7 +24,7 @@ note: while trying to match `==`
    = note: this error originates in the macro `$crate::constraints` which comes from the expansion of the macro `constraints` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: no rules expected the token `;`
-  --> tests/ui/fails.rs:15:53
+Error:   --> tests/ui/fails.rs:15:53
    |
 15 |     let [a, b, c] = constraints![ == 1, == 10%, == 2; 4];
    |                                                     ^ no rules expected this token in macro call
@@ -36,7 +36,7 @@ note: while trying to match `%`
    |                   ^
 
 error: first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semicolon
-  --> tests/ui/fails.rs:17:13
+Error:   --> tests/ui/fails.rs:17:13
    |
 17 |     let _ = span!(Modifier::BOLD, "hello world");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ error: first parameter must be a formatting specifier followed by a comma OR a `
    = note: this error originates in the macro `span` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument never used
-  --> tests/ui/fails.rs:19:28
+Error:   --> tests/ui/fails.rs:19:28
    |
 19 |     let _ = span!("hello", "hello world");
    |                   -------  ^^^^^^^^^^^^^ argument never used
@@ -52,13 +52,13 @@ error: argument never used
    |                   formatting specifier missing
 
 error[E0527]: pattern requires 2 elements but array has 3
- --> tests/ui/fails.rs:8:9
+Error:  --> tests/ui/fails.rs:8:9
   |
 8 |     let [a, b] = constraints![
   |         ^^^^^^ expected 3 elements
 
 error[E0277]: the trait bound `Style: From<&str>` is not satisfied
-  --> tests/ui/fails.rs:21:19
+Error:   --> tests/ui/fails.rs:21:19
    |
 21 |     let _ = span!("hello"; "hello world");
    |             ------^^^^^^^----------------
@@ -67,14 +67,14 @@ error[E0277]: the trait bound `Style: From<&str>` is not satisfied
    |             required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
+             <Style as From<crossterm::style::content_style::ContentStyle>>
+             <Style as From<Color>>
+             <Style as From<Modifier>>
              <Style as From<(Color, Color)>>
              <Style as From<(Color, Color, Modifier)>>
              <Style as From<(Color, Color, Modifier, Modifier)>>
              <Style as From<(Color, Modifier)>>
              <Style as From<(Modifier, Modifier)>>
-             <Style as From<Color>>
-             <Style as From<Modifier>>
-             <Style as From<crossterm::style::content_style::ContentStyle>>
    = note: required for `&str` to implement `Into<Style>`
 note: required by a bound in `Span::<'a>::styled`
   --> $CARGO/ratatui-0.26.2/src/text/span.rs

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -35,7 +35,7 @@ note: while trying to match `%`
    |     (== $token:tt %) => {
    |                   ^
 
-error: first parameter must be a formatting specifier followed by a comma OR a `ratatui::style::Style` followed by a semi-colon
+error: first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semi-colon
   --> tests/ui/fails.rs:17:13
    |
 17 |     let _ = span!(Modifier::BOLD, "hello world");

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -35,7 +35,7 @@ note: while trying to match `%`
    |     (== $token:tt %) => {
    |                   ^
 
-error: first parameter must be a `ratatui::style::Style` followed by a semi-colon
+error: first parameter must be a formatting specifier followed by a comma OR a `ratatui::style::Style` followed by a semi-colon
   --> tests/ui/fails.rs:17:13
    |
 17 |     let _ = span!(Modifier::BOLD, "hello world");

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -43,44 +43,8 @@ error: first parameter must be a formatting specifier followed by a comma OR a `
    |
    = note: this error originates in the macro `span` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: argument never used
-  --> tests/ui/fails.rs:19:28
-   |
-19 |     let _ = span!("hello", "hello world");
-   |                   -------  ^^^^^^^^^^^^^ argument never used
-   |                   |
-   |                   formatting specifier missing
-
 error[E0527]: pattern requires 2 elements but array has 3
  --> tests/ui/fails.rs:8:9
   |
 8 |     let [a, b] = constraints![
   |         ^^^^^^ expected 3 elements
-
-error[E0277]: the trait bound `Style: From<&str>` is not satisfied
-  --> tests/ui/fails.rs:21:19
-   |
-21 |     let _ = span!("hello"; "hello world");
-   |             ------^^^^^^^----------------
-   |             |     |
-   |             |     the trait `From<&str>` is not implemented for `Style`, which is required by `&str: Into<Style>`
-   |             required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `From<T>`:
-             <Style as From<(Color, Color)>>
-             <Style as From<(Color, Color, Modifier)>>
-             <Style as From<(Color, Color, Modifier, Modifier)>>
-             <Style as From<(Color, Modifier)>>
-             <Style as From<(Modifier, Modifier)>>
-             <Style as From<crossterm::style::content_style::ContentStyle>>
-             <Style as From<Color>>
-             <Style as From<Modifier>>
-   = note: required for `&str` to implement `Into<Style>`
-note: required by a bound in `Span::<'a>::styled`
-  --> $CARGO/ratatui-0.26.2/src/text/span.rs
-   |
-   |     pub fn styled<T, S>(content: T, style: S) -> Self
-   |            ------ required by a bound in this associated function
-...
-   |         S: Into<Style>,
-   |            ^^^^^^^^^^^ required by this bound in `Span::<'a>::styled`

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -43,6 +43,14 @@ error: first parameter must be a formatting specifier followed by a comma OR a `
    |
    = note: this error originates in the macro `span` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: argument never used
+  --> tests/ui/fails.rs:19:28
+   |
+19 |     let _ = span!("hello", "hello world");
+   |                   -------  ^^^^^^^^^^^^^ argument never used
+   |                   |
+   |                   formatting specifier missing
+
 error[E0527]: pattern requires 2 elements but array has 3
  --> tests/ui/fails.rs:8:9
   |

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -1,5 +1,5 @@
 error: No rules expected the token `,` while trying to match the end of the macro
-Error:  --> tests/ui/fails.rs:5:5
+ --> tests/ui/fails.rs:5:5
   |
 5 |     constraints![,];
   |     ^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ Error:  --> tests/ui/fails.rs:5:5
   = note: this error originates in the macro `$crate::constraints` which comes from the expansion of the macro `constraints` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-Error:   --> tests/ui/fails.rs:8:18
+  --> tests/ui/fails.rs:8:18
    |
 8  |       let [a, b] = constraints![
    |  __________________^
@@ -24,7 +24,7 @@ note: while trying to match `==`
    = note: this error originates in the macro `$crate::constraints` which comes from the expansion of the macro `constraints` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: no rules expected the token `;`
-Error:   --> tests/ui/fails.rs:15:53
+  --> tests/ui/fails.rs:15:53
    |
 15 |     let [a, b, c] = constraints![ == 1, == 10%, == 2; 4];
    |                                                     ^ no rules expected this token in macro call
@@ -36,7 +36,7 @@ note: while trying to match `%`
    |                   ^
 
 error: first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semicolon
-Error:   --> tests/ui/fails.rs:17:13
+  --> tests/ui/fails.rs:17:13
    |
 17 |     let _ = span!(Modifier::BOLD, "hello world");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ Error:   --> tests/ui/fails.rs:17:13
    = note: this error originates in the macro `span` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument never used
-Error:   --> tests/ui/fails.rs:19:28
+  --> tests/ui/fails.rs:19:28
    |
 19 |     let _ = span!("hello", "hello world");
    |                   -------  ^^^^^^^^^^^^^ argument never used
@@ -52,13 +52,13 @@ Error:   --> tests/ui/fails.rs:19:28
    |                   formatting specifier missing
 
 error[E0527]: pattern requires 2 elements but array has 3
-Error:  --> tests/ui/fails.rs:8:9
+ --> tests/ui/fails.rs:8:9
   |
 8 |     let [a, b] = constraints![
   |         ^^^^^^ expected 3 elements
 
 error[E0277]: the trait bound `Style: From<&str>` is not satisfied
-Error:   --> tests/ui/fails.rs:21:19
+  --> tests/ui/fails.rs:21:19
    |
 21 |     let _ = span!("hello"; "hello world");
    |             ------^^^^^^^----------------
@@ -67,14 +67,14 @@ Error:   --> tests/ui/fails.rs:21:19
    |             required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
-             <Style as From<crossterm::style::content_style::ContentStyle>>
-             <Style as From<Color>>
-             <Style as From<Modifier>>
              <Style as From<(Color, Color)>>
              <Style as From<(Color, Color, Modifier)>>
              <Style as From<(Color, Color, Modifier, Modifier)>>
              <Style as From<(Color, Modifier)>>
              <Style as From<(Modifier, Modifier)>>
+             <Style as From<Color>>
+             <Style as From<Modifier>>
+             <Style as From<crossterm::style::content_style::ContentStyle>>
    = note: required for `&str` to implement `Into<Style>`
 note: required by a bound in `Span::<'a>::styled`
   --> $CARGO/ratatui-0.26.2/src/text/span.rs

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -35,8 +35,52 @@ note: while trying to match `%`
    |     (== $token:tt %) => {
    |                   ^
 
+error: first parameter must be a `ratatui::style::Style` followed by a semi-colon
+  --> tests/ui/fails.rs:17:13
+   |
+17 |     let _ = span!(Modifier::BOLD, "hello world");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `span` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: argument never used
+  --> tests/ui/fails.rs:19:28
+   |
+19 |     let _ = span!("hello", "hello world");
+   |                   -------  ^^^^^^^^^^^^^ argument never used
+   |                   |
+   |                   formatting specifier missing
+
 error[E0527]: pattern requires 2 elements but array has 3
  --> tests/ui/fails.rs:8:9
   |
 8 |     let [a, b] = constraints![
   |         ^^^^^^ expected 3 elements
+
+error[E0277]: the trait bound `Style: From<&str>` is not satisfied
+  --> tests/ui/fails.rs:21:19
+   |
+21 |     let _ = span!("hello"; "hello world");
+   |             ------^^^^^^^----------------
+   |             |     |
+   |             |     the trait `From<&str>` is not implemented for `Style`, which is required by `&str: Into<Style>`
+   |             required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `From<T>`:
+             <Style as From<(Color, Color)>>
+             <Style as From<(Color, Color, Modifier)>>
+             <Style as From<(Color, Color, Modifier, Modifier)>>
+             <Style as From<(Color, Modifier)>>
+             <Style as From<(Modifier, Modifier)>>
+             <Style as From<Color>>
+             <Style as From<Modifier>>
+             <Style as From<crossterm::style::content_style::ContentStyle>>
+   = note: required for `&str` to implement `Into<Style>`
+note: required by a bound in `Span::<'a>::styled`
+  --> $CARGO/ratatui-0.26.2/src/text/span.rs
+   |
+   |     pub fn styled<T, S>(content: T, style: S) -> Self
+   |            ------ required by a bound in this associated function
+...
+   |         S: Into<Style>,
+   |            ^^^^^^^^^^^ required by this bound in `Span::<'a>::styled`

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -35,7 +35,7 @@ note: while trying to match `%`
    |     (== $token:tt %) => {
    |                   ^
 
-error: first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semi-colon
+error: first parameter must be a formatting specifier followed by a comma OR a `Style` followed by a semicolon
   --> tests/ui/fails.rs:17:13
    |
 17 |     let _ = span!(Modifier::BOLD, "hello world");

--- a/tests/ui/fails.stderr
+++ b/tests/ui/fails.stderr
@@ -72,9 +72,9 @@ error[E0277]: the trait bound `Style: From<&str>` is not satisfied
              <Style as From<(Color, Color, Modifier, Modifier)>>
              <Style as From<(Color, Modifier)>>
              <Style as From<(Modifier, Modifier)>>
+             <Style as From<crossterm::style::content_style::ContentStyle>>
              <Style as From<Color>>
              <Style as From<Modifier>>
-             <Style as From<crossterm::style::content_style::ContentStyle>>
    = note: required for `&str` to implement `Into<Style>`
 note: required by a bound in `Span::<'a>::styled`
   --> $CARGO/ratatui-0.26.2/src/text/span.rs


### PR DESCRIPTION
With this PR, if a user accidentally uses `,` as a separator when the first argument is a style, they'll will get a better compiler error message:

<img width="748" alt="image" src="https://github.com/ratatui-org/ratatui-macros/assets/1813121/58ec025c-56c8-4a4a-998f-7a48a6b327fd">

This also updates the docstrings to reiterate that `,` must be used for format specifier and `;` must be used for style. 