### PR TITLE
feat(layout)!: Use *= instead of =*

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+format_macro_bodies = true
+format_macro_matchers = true

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ use ratatui::prelude::*;
 use ratatui_macros::constraints;
 
 assert_eq!(
-    constraints![==50, ==30%, >=3, <=1, ==1/2, =*1],
+    constraints![==50, ==30%, >=3, <=1, ==1/2, *=1],
     [
         Constraint::Length(50),
         Constraint::Percentage(30),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -13,7 +13,7 @@
 /// assert_eq!(constraint!(== 1 / 3), Constraint::Ratio(1, 3));
 /// assert_eq!(constraint!(== 3), Constraint::Length(3));
 /// assert_eq!(constraint!(== 10 %), Constraint::Percentage(10));
-/// assert_eq!(constraint!(=* 1), Constraint::Fill(1));
+/// assert_eq!(constraint!(*= 1), Constraint::Fill(1));
 /// ```
 #[macro_export]
 macro_rules! constraint {
@@ -32,7 +32,7 @@ macro_rules! constraint {
     (== $expr:expr) => {
         ratatui::layout::Constraint::Length($expr)
     };
-    (=* $expr:expr) => {
+    (*= $expr:expr) => {
         ratatui::layout::Constraint::Fill($expr)
     };
 }
@@ -56,7 +56,7 @@ macro_rules! constraint {
 /// use ratatui::prelude::*;
 /// use ratatui_macros::constraints;
 /// assert_eq!(
-///     constraints![==50, ==30%, >=3, <=1, ==1/2, =*1],
+///     constraints![==50, ==30%, >=3, <=1, ==1/2, *=1],
 ///     [
 ///         Constraint::Length(50),
 ///         Constraint::Percentage(30),


### PR DESCRIPTION
This is a follow up to https://github.com/ratatui-org/ratatui-macros/pull/34

`*=` is more consistent with the other symbols, e.g. `<=`, `>=`.

It is also more in line with what other programming languages do.

```
$ python
Python 3.10.13 | packaged by conda-forge | (main, Oct 26 2023, 18:09:17) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> x = 1
>>> x *= 2
>>> x
2
```

`=*` throws an error. 

```
>>> x =* 2
  File "<stdin>", line 1
SyntaxError: can't use starred expression here
>>>
```