### PR TITLE
fix: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2024-08-12
+
+### 🐛 Bug Fixes
+
+- Bump version to 0.5.0
 
 ## [0.4.4](https://github.com/ratatui-org/ratatui-macros/compare/v0.4.3...v0.4.4) - 2024-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "cargo-husky",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-macros"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 authors = ["The Ratatui Developers"]
 description = "Macros for Ratatui"


### PR DESCRIPTION
Updating Ratatui to 0.28 requires a major version bump
Fixes: https://github.com/ratatui-org/ratatui-macros/issues/68
